### PR TITLE
Disambiguation follow-ups: config logging exposure and Docker context ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,3 +44,4 @@ venv.bak/
 *.swp
 *.swo
 *~
+test_dirs/

--- a/namer/configuration.py
+++ b/namer/configuration.py
@@ -552,6 +552,11 @@ class NamerConfig:
             self.dest_dir = self.dest_dir.resolve()
         if hasattr(self, 'failed_dir'):
             self.failed_dir = self.failed_dir.resolve()
+        if hasattr(self, 'ambiguous_dir'):
+            self.ambiguous_dir = self.ambiguous_dir.resolve()
+        # Resolve file logging directory like other dirs (if present)
+        if hasattr(self, 'file_logging_directory'):
+            self.file_logging_directory = self.file_logging_directory.resolve()
 
     def __str__(self):
         config = self.to_dict()
@@ -668,6 +673,7 @@ class NamerConfig:
                 'watch_dir': str(self.watch_dir),
                 'work_dir': str(self.work_dir),
                 'failed_dir': str(self.failed_dir),
+                'ambiguous_dir': str(self.ambiguous_dir) if hasattr(self, 'ambiguous_dir') else '',
                 'dest_dir': str(self.dest_dir),
                 'retry_time': self.retry_time,
                 'extra_sleep_time': self.extra_sleep_time,
@@ -682,6 +688,11 @@ class NamerConfig:
                 'add_complete_column': self.add_complete_column,
                 'debug': self.debug,
                 'console_format': self.console_format,
+                'file_logging_enabled': self.file_logging_enabled,
+                'file_logging_level': self.file_logging_level,
+                'file_logging_rotation': self.file_logging_rotation,
+                'file_logging_retention': self.file_logging_retention,
+                'file_logging_directory': str(self.file_logging_directory) if hasattr(self, 'file_logging_directory') else '',
                 'manual_mode': self.manual_mode,
                 'diagnose_errors': self.diagnose_errors,
             },


### PR DESCRIPTION
This PR extracts the minimal, review-focused fixes from the previous disambiguation branch for a clean review.

What’s included
- Expose file logging fields in NamerConfig.to_dict() and resolve file_logging_directory in __init__
  - File: `namer/configuration.py`
  - Ensures `ambiguous_dir` and `file_logging_directory` are resolved to absolute paths
  - Surfaces `file_logging_enabled`, `file_logging_level`, `file_logging_rotation`, `file_logging_retention`, and `file_logging_directory` under the existing `Watchdog Config` block
- Reduce Docker build context size
  - File: `.dockerignore`
  - Ignore both `test/integration/` and `test_dirs/`

What’s not included
- No docstring/regeneration or broader refactors
- No provider logic changes
- No Dockerfile or CI changes beyond the `.dockerignore` entry

Rationale
- Keeps the PR small and directly aligned to prior review comments for faster merge.

Acceptance
- `namer/configuration.py` resolves paths in `__init__` and exposes the logging fields via `to_dict()`
- `.dockerignore` contains both `test/integration/` and `test_dirs/`

Thank you for reviewing!